### PR TITLE
Always give physgun last

### DIFF
--- a/lua/cfc_loadouts/server/sv_cfc_loadout.lua
+++ b/lua/cfc_loadouts/server/sv_cfc_loadout.lua
@@ -35,6 +35,7 @@ local function giveWeapons( ply )
     end
 
     ply:Give( "weapon_physgun" )
+    ply:SetActiveWeapon( "weapon_physgun" )
 
     return true
 end

--- a/lua/cfc_loadouts/server/sv_cfc_loadout.lua
+++ b/lua/cfc_loadouts/server/sv_cfc_loadout.lua
@@ -34,6 +34,8 @@ local function giveWeapons( ply )
         ply:SetAmmo( v, k )
     end
 
+    ply:Give( "weapon_physgun" )
+
     return true
 end
 


### PR DESCRIPTION
This should fix an issue with spawn protection where the player isn't holding a physgun after the `PlayerLoadout` hook
